### PR TITLE
Akkhan's Manacles on single target when not using Shattering Throw

### DIFF
--- a/simulator/crusader.js
+++ b/simulator/crusader.js
@@ -296,7 +296,7 @@
     });
   }
   function bs_akkhans_fix() {
-    this.factor = 1 + 0.01 * (Sim.stats.leg_akkhansmanacles || 0) / this.targets;
+    this.factor = 1 + 0.01 * (Sim.stats.leg_akkhansmanacles || 0) / Math.min(this.targets, Sim.target.count);
   }
   skills.blessedshield = {
     offensive: true,


### PR DESCRIPTION
Blessed Shield with Akkhan's Manacles on single target when not using Shattering Throw does not properly apply the Akkhan's Manacles boost.

I can't seem to get the code running on my local machine (missing `php/session.php` and missing `external/all.css`) so this fix is untested and just based on a hunch, because without running it it's to hard for me to figure out exactly how things work.

It also doesn't seem like this is the correct place to use `Sim.target.count` ...
