### PR TITLE
Shattering Throw should not apply to the first target

### DIFF
--- a/simulator/crusader.js
+++ b/simulator/crusader.js
@@ -316,7 +316,7 @@
         break;
       case "d":
         dmg.targets = 1;
-        Sim.damage({delay: dmg.delay, targets: 3 * (4 + (Sim.stats.leg_jekangbord || 0)), coeff: 1.7});
+        Sim.damage({delay: dmg.delay, targets: Math.min(3 * (4 + (Sim.stats.leg_jekangbord || 0)), Sim.target.count - 1), coeff: 1.7});
         break;
       case "e":
         delete dmg.delay;


### PR DESCRIPTION
Shattering Throw should not apply it's extra damage to the first target.

Same story as #3;  
I can't seem to get the code running on my local machine (missing `php/session.php` and missing `external/all.css`) so this fix is untested and just based on a hunch, because without running it it's to hard for me to figure out exactly how things work.

It also doesn't seem like this is the correct place to use `Sim.target.count` ...
