### PR TITLE
maxstacks for Bane of the Stricken to 360

### DIFF
--- a/simulator/itemspecial.js
+++ b/simulator/itemspecial.js
@@ -177,7 +177,7 @@
       if (Sim.time >= next) {
         if (--counter < 0) {
           Sim.addBuff("stricken", {dmgmul: 0.8 + level * 0.01}, {
-            maxstacks: 9999,
+            maxstacks: 360,
           });
           counter = Sim.target.count - 1;
         }


### PR DESCRIPTION
with the 9999 cap Bane of the Stricken is so insanely good it can't really be compared to any other gem ...

with 2 attacks per second you'd have 360 stacks after 3min, it seems reasonable to me to cap it at that since that is about what a RG fight could take.

it would be more preferred to set a time for the simulation and for example run the same sim 10x and provide the average result, but that's awefully complex for this problem xD