### PR TITLE
flying dragon: reduce proc rate to 0.04

### DIFF
--- a/simulator/itemspecial.js
+++ b/simulator/itemspecial.js
@@ -807,7 +807,7 @@
     if (Sim.stats.charClass !== "monk") return;
     var next = 0;
     Sim.register("oncast", function(data) {
-      if (Sim.time >= next && data.offensive && Sim.random("flyingdragon", 0.05)) {
+      if (Sim.time >= next && data.offensive && Sim.random("flyingdragon", 0.04)) {
         Sim.addBuff("flyingdragon", {weaponaps_percent: 100}, {duration: 420});
         next = Sim.time + 300;
       }


### PR DESCRIPTION
Value taken from http://freakinsweetapps.com/flying-dragon-up-time-calculator/

Hopefully this fixes the unrealistically high FD uptime in d3planner.
That said, even if I go to that simulator and change the 0.04 in its
source code to 0.05, I don't get values as insanely high as d3planner,
so some other bug might also be present.

Simulating R6 gen on d3planner gives me insanely high FD uptimes of 93%+. There's no way this is realistic. On the website I linked, plugging in my adjusted APS gives me an uptime of ~70% (no StI) and ~80 (StI) which sounds far more like reality.

I noticed they use the same ICD/duration, but they have a proc rate of 0.04, not 0.05. But even if I change their simulator to 0.05 it doesn't compute 93% uptime unless I actually set my base APS to something like 8-9, which is clearly absurd.

What is d3planner doing differently here? Is it failing to take into account the ICD properly, perhaps? I ask because if I modify that simulator to remove the ICD (and set the proc coefficient to 0.05), I also get 93% from it.