### PR TITLE
Fix default Sweeping Wind stacks

### DIFF
--- a/scripts/data/skill_monk.js
+++ b/scripts/data/skill_monk.js
@@ -556,7 +556,7 @@ DiabloCalc.skills.monk = {
       c: "Cyclone",
     },
     range: {x: 10, e: 10, a: 10, b: 14, d: 10, c: 10},
-    params: [{min: 0, max: "3+(leg_vengefulwind?3:1)+leg_vengefulwind_p2", name: "Stacks", buffs: false}],
+    params: [{min: 0, max: "3+(leg_vengefulwind?3:0)+leg_vengefulwind_p2", name: "Stacks", buffs: false}],
     info: function(rune, stats) {
       var res = {"Cost": {cost: 75}, "DPS": {elem: "phy", aps: true, coeff: 1.05, factors: {"Stacks": this.params[0].val}, total: true}};
       if (rune === "e") res["DPS"].elem = "col";

--- a/scripts/data/skill_witchdoctor.js
+++ b/scripts/data/skill_witchdoctor.js
@@ -484,7 +484,7 @@ DiabloCalc.skills.witchdoctor = {
       var stacks = this.params[0].val;
       var res = {int_percent: stacks * 3};
       if (stats.leg_lakumbasornament) res.dmgred = 6 * stacks;
-      if (rune === "d" || stats.set_jadeharvester_4pc) res.maxmana_percent = stacks * 5;
+      if (rune === "d" || stats.set_jadeharvester_4pc) res.maxmana = (stacks > 5 ? 5 : stacks) * 750 * 0.05;
       if (rune === "c" || stats.set_jadeharvester_4pc) res.armor_percent = stacks * 10;
       if (rune === "b" || stats.set_jadeharvester_4pc) res.extrams = stacks * 5;
       return res;


### PR DESCRIPTION
ternary for old Vengeful Wind returned 3 or 1 instead of 3 or 0 fixing #321 